### PR TITLE
Force Engine Versions

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict = true

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "commandmc",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "GPLv3",
       "dependencies": {
         "@prisma/client": "^4.2.1",
         "@twurple/api": "^5.2.1",
@@ -25,6 +25,10 @@
       "devDependencies": {
         "@types/cryptr": "^4.0.1",
         "@types/express": "^4.17.13"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ""
       }
     },
     "node_modules/@d-fischer/cache-decorators": {

--- a/package.json
+++ b/package.json
@@ -39,5 +39,10 @@
   "devDependencies": {
     "@types/cryptr": "^4.0.1",
     "@types/express": "^4.17.13"
+  },
+  "engines": {
+    "node": ">=14",
+    "npm": ">=7.4",
+    "yarn": "please-use-npm"
   }
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR forces the following versions:

- NPM: `>=7.4`
- Node: `>=14`
- Yarn: disable usage